### PR TITLE
Typo + Api Path versioning

### DIFF
--- a/src/main/java/com/online_store/configuration/WebSecurityConfig.java
+++ b/src/main/java/com/online_store/configuration/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.online_store.configuration;
 
+import com.online_store.constants.Path;
 import com.online_store.security.jwt.AuthEntryPointJwt;
 import com.online_store.security.jwt.AuthTokenFilter;
 import com.online_store.security.services.UserDetailsServiceImpl;
@@ -57,9 +58,11 @@ public class WebSecurityConfig {
         http.csrf(csrf -> csrf.disable())
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(unauthorizedHandler))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth ->
-                        auth.requestMatchers("/api/auth/**").permitAll()
-                                .anyRequest().authenticated()
+                .authorizeHttpRequests(registry -> registry
+                        .requestMatchers(Path.AUTH + "/**").permitAll()
+                        .requestMatchers(Path.PRODUCT + "/**").permitAll()
+                        .requestMatchers(Path.PRODUCT + "/list").permitAll()
+                        .anyRequest().authenticated()
                 );
         http.authenticationProvider(authenticationProvider());
         http.addFilterBefore(authenticationJwtTokenFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/online_store/constants/Path.java
+++ b/src/main/java/com/online_store/constants/Path.java
@@ -1,14 +1,12 @@
 package com.online_store.constants;
 
 public class Path {
-    // TODO: check wtf with AuthEntryPoint when you add v1 to auth pathname
-    //    public static final String API_VERSION = "/v1";
-//    public static final String API_PATHNAME = "api" + API_VERSION;
-//    public static final String AUTH = API_PATHNAME + "/auth";
-    public static final String API_PATHNAME = "/api";
+    public static final String API_VERSION = "/v1";
+    public static final String API_PATHNAME = "/api" + API_VERSION;
     public static final String AUTH = API_PATHNAME + "/auth";
     public static final String PRODUCT = API_PATHNAME + "/product";
     public static final String ORDER = API_PATHNAME + "/order";
+    public static final String CATEGORY = API_PATHNAME + "/category";
 
     private Path() {
     }

--- a/src/main/java/com/online_store/security/jwt/AuthTokenFilter.java
+++ b/src/main/java/com/online_store/security/jwt/AuthTokenFilter.java
@@ -53,7 +53,7 @@ public class AuthTokenFilter extends OncePerRequestFilter {
     }
 
     private String parseJwt(HttpServletRequest request) {
-        String jwt = jwtUtils.geJwtFromCookies(request);
+        String jwt = jwtUtils.getJwtFromCookies(request);
         return jwt;
     }
 

--- a/src/main/java/com/online_store/security/jwt/JwtUtils.java
+++ b/src/main/java/com/online_store/security/jwt/JwtUtils.java
@@ -29,7 +29,7 @@ public class JwtUtils {
     @Value("${com.example.demo.jwtCookieName}")
     private String jwtCookie;
 
-    public String geJwtFromCookies(HttpServletRequest request) {
+    public String getJwtFromCookies(HttpServletRequest request) {
         Cookie cookie = WebUtils.getCookie(request, jwtCookie);
         if (cookie != null) {
             return cookie.getValue();

--- a/src/main/java/com/online_store/security/jwt/JwtUtils.java
+++ b/src/main/java/com/online_store/security/jwt/JwtUtils.java
@@ -1,5 +1,6 @@
 package com.online_store.security.jwt;
 
+import com.online_store.constants.Path;
 import com.online_store.security.services.UserDetailsImpl;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
@@ -42,7 +43,7 @@ public class JwtUtils {
         String jwt = generateTokenFromUsername(userPrincipal.getUsername());
         int dayDuration = 86400; // day duration in seconds
         ResponseCookie cookie = ResponseCookie.from(jwtCookie, jwt)
-                .path("/api")
+                .path(Path.API_PATHNAME)
                 .maxAge(dayDuration)
                 .httpOnly(true)
                 .build();
@@ -51,7 +52,7 @@ public class JwtUtils {
 
     public ResponseCookie getCleanJwtCookie() {
         ResponseCookie cookie = ResponseCookie.from(jwtCookie, null)
-                .path("/api")
+                .path(Path.API_PATHNAME)
                 .build();
         return cookie;
     }


### PR DESCRIPTION
- fixed typo in method's name in `JwtUtils.class`
- added new request matchers in `configuration.WebSecurityConfig`
- included `API_VERSION` constant to `API_PATHNAME` in `constants.Path` to follow best practices